### PR TITLE
Ruby updates for heroku-20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'jbuilder'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-gem "twitter-bootstrap-rails", git: 'git://github.com/seyhunak/twitter-bootstrap-rails.git' # rails 6 support on master
+gem "twitter-bootstrap-rails", github: 'seyhunak/twitter-bootstrap-rails' # rails 6 support on master
 gem "bunny"
 gem 'devise'
 gem 'redis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/seyhunak/twitter-bootstrap-rails.git
+  remote: https://github.com/seyhunak/twitter-bootstrap-rails.git
   revision: a9a5b41735cdb37e0dcb878eb25dcdf6174412cd
   specs:
     twitter-bootstrap-rails (4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/alexpeattie/heroku_secrets.git
+  revision: 717af8e0acf399bc88d2c8c1a7e230023942af0f
+  specs:
+    heroku_secrets (0.0.2)
+
+GIT
   remote: https://github.com/seyhunak/twitter-bootstrap-rails.git
   revision: a9a5b41735cdb37e0dcb878eb25dcdf6174412cd
   specs:
@@ -7,12 +13,6 @@ GIT
       execjs (~> 2.7)
       less-rails (>= 3.0, < 5.0)
       railties (>= 5.0, < 7.0)
-
-GIT
-  remote: https://github.com/alexpeattie/heroku_secrets.git
-  revision: 717af8e0acf399bc88d2c8c1a7e230023942af0f
-  specs:
-    heroku_secrets (0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -139,7 +139,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -290,4 +292,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.11
+   2.2.12


### PR DESCRIPTION
Mises à jour minimales pour pouvoir déployer sur la stack heroku-20

Ruby 2.6.9
update mimemagic 0.3.5 => 0.3.10